### PR TITLE
Adding tracking of user positions. fixes #55

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2,9 +2,11 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@^1.0.14": "1.0.16",
+    "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/expect@*": "1.0.17",
     "jsr:@std/internal@^1.0.10": "1.0.12",
-    "jsr:@std/internal@^1.0.12": "1.0.12"
+    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/testing@*": "1.0.16"
   },
   "jsr": {
     "@std/assert@1.0.16": {
@@ -16,12 +18,19 @@
     "@std/expect@1.0.17": {
       "integrity": "316b47dd65c33e3151344eb3267bf42efba17d1415425f07ed96185d67fc04d9",
       "dependencies": [
-        "jsr:@std/assert",
+        "jsr:@std/assert@^1.0.14",
         "jsr:@std/internal@^1.0.10"
       ]
     },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/testing@1.0.16": {
+      "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.15",
+        "jsr:@std/internal@^1.0.12"
+      ]
     }
   },
   "workspace": {

--- a/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/actions/User/index.ts
+++ b/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/actions/User/index.ts
@@ -1,0 +1,105 @@
+/**
+ * Polymarket User Actions. General actions for fetching and displaying polymarket user data.
+ * 
+ * @file Polymarket User Actions
+ * @description ActionHandlers for fetching and displaying polymarket data.
+ * @note ActionHandlers are functions that take a TerminalUserStateConfig and return a Promise<CommandState>
+ * @see {@link ActionHandler}
+ */
+
+import { project, pipe, set, filter, toLower, lensProp, map,
+    lensPath, view, defaultTo, zip, tap, find,
+    props, prop,
+    reduce
+} from "ramda";
+import terminalKit from "terminal-kit";
+const { terminal } = terminalKit;
+import PredictionMarketsData from "../../model/index.ts";
+import {
+    CommandResultType,
+    CommandState,
+    LogLevel
+} from "../../../../types.ts";
+import { TerminalUserStateConfig } from "../../../../types.ts";
+import { ActionHandler } from "../../../../types.ts";
+import chalk from "chalk";
+import { inspectLogger } from "../../../../utils/logging.ts"
+
+export const processUserData = pipe(
+    project(['title', 'size', 'currentValue', 'slug']),
+);
+
+const currentValueProp = prop('currentValue');
+const realizedPnlProp = prop('realizedPnl');
+
+export const processUserAccountData = pipe(
+    reduce((acc, val: any) => {
+        return {
+            currentValue: acc.currentValue + currentValueProp(val),
+            realizedPnl: acc.realizedPnl + realizedPnlProp(val),
+        };
+    }, { currentValue: 0, realizedPnl: 0 }),
+);
+
+/**
+ * Fetches user positions for the given user address.
+ * @param st Terminal User State 
+ * @param address Polymarket User Address. 
+ * @returns CommandState 
+ */
+export const predictionUserPositionsHandler: ActionHandler = (st: TerminalUserStateConfig) => async (address?: string): Promise<CommandState> => {
+    const applicationLogging = inspectLogger(st);
+    
+    if (!address) {
+        console.log("No address provided");
+        return {
+            result: { type: CommandResultType.Success },
+            state: st,
+        };
+    }
+    
+    const response  = await PredictionMarketsData.polyMarketData.user.getPositions(address);
+    applicationLogging(LogLevel.Info)("Fetched Data for user address: " + address);
+    applicationLogging(LogLevel.Debug)(response);
+    
+    console.log(chalk.blue("User Address: ") + address)
+    console.log(chalk.blue.bold("User Positions"))
+    
+    const userData = processUserData(response);
+    const accountData = processUserAccountData(userData);
+
+    terminal.table([
+        ["Title", "Size", "Current Value", "Slug"],
+        ...userData.map((item: any) => [item.title, item.size, item.currentValue, item.slug])
+    ], {
+        hasBorder: true,
+        contentHasMarkup: true,
+        borderChars: 'lightRounded',
+        borderAttr: { color: 'green' },
+        textAttr: { bgColor: 'default' },
+        firstRowTextAttr: { bgColor: 'green' },
+        width: 180,
+        fit: true
+    });
+
+    console.log(chalk.blue.bold("Account Data"))
+
+    terminal.table([
+        ["Current Value", "Realized PnL"],
+        [accountData.currentValue, accountData.realizedPnl]
+    ], {
+        hasBorder: true,
+        contentHasMarkup: true,
+        borderChars: 'lightRounded',
+        borderAttr: { color: 'blue' },
+        textAttr: { bgColor: 'default' },
+        firstRowTextAttr: { bgColor: 'green' },
+        width: 180,
+        fit: true
+    });
+    
+    return {
+        result: { type: CommandResultType.Success },
+        state: st,
+    };
+}

--- a/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/actions/User/index.ts
+++ b/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/actions/User/index.ts
@@ -25,6 +25,9 @@ import { ActionHandler } from "../../../../types.ts";
 import chalk from "chalk";
 import { inspectLogger } from "../../../../utils/logging.ts"
 
+/**
+ * Pick the title, size, currentValue, and slug from the response.
+ */
 export const processUserData = pipe(
     project(['title', 'size', 'currentValue', 'slug']),
 );
@@ -32,6 +35,11 @@ export const processUserData = pipe(
 const currentValueProp = prop('currentValue');
 const realizedPnlProp = prop('realizedPnl');
 
+/**
+ * Processes user account data from response, aggregating their net values and pnls..
+ * @param data User account data.
+ * @returns Processed user account data.
+ */
 export const processUserAccountData = pipe(
     reduce((acc, val: any) => {
         return {
@@ -66,7 +74,7 @@ export const predictionUserPositionsHandler: ActionHandler = (st: TerminalUserSt
     console.log(chalk.blue.bold("User Positions"))
     
     const userData = processUserData(response);
-    const accountData = processUserAccountData(userData);
+    const accountData = processUserAccountData(response);
 
     terminal.table([
         ["Title", "Size", "Current Value", "Slug"],

--- a/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/actions/User/user_test.ts
+++ b/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/actions/User/user_test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, it } from "jsr:@std/testing/bdd";
+import { expect } from "jsr:@std/expect";
+
+import { processUserData, processUserAccountData } from "./index.ts"
+
+const mockUserResponse = [{
+    proxyWallet: "0x1abe1368601330a310162064e04d3c2628cb6497",
+    asset: "11631590502751337995086584451805403545770829549632613492416833230270784409909",
+    conditionId: "0xabb86b080e9858dcb3f46954010e49b6f539c20036856c7f999395bfd58d01e6",
+    size: 63802.952936,
+    avgPrice: 0.164567,
+    initialValue: 10499.860555818712,
+    currentValue: 11803.54629316,
+    cashPnl: 1303.6857373412877,
+    percentPnl: 12.416219533685364,
+    totalBought: 63802.952936,
+    realizedPnl: 3,
+    percentRealizedPnl: 12.416219533685364,
+    curPrice: 0.185,
+    redeemable: false,
+    mergeable: false,
+    title: "US strikes Iran by January 31, 2026?",
+    slug: "us-strikes-iran-by-january-31-2026",
+    icon: "https://polymarket-upload.s3.us-east-2.amazonaws.com/us-strikes-iran-by-october-3-2sVnIHq3sjqF.jpg",
+    eventId: "114242",
+    eventSlug: "us-strikes-iran-by",
+    outcome: "Yes",
+    outcomeIndex: 0,
+    oppositeOutcome: "No",
+    oppositeAsset: "13294549611854156060952327202052855585194847446707854951585060180328600525494",
+    endDate: "2026-01-31",
+    negativeRisk: false
+  },
+  {
+    proxyWallet: "0x1abe1368601330a310162064e04d3c2628cb6497",
+    asset: "114073431155826730926052468626599502581519892859155799641358176120253844422606",
+    conditionId: "0x4b02efe53e631ada84681303fd66d79ad615f3d2b6a28b4633d43d935f89af58",
+    size: 29724.338558,
+    avgPrice: 0.28764,
+    initialValue: 8549.90874282312,
+    currentValue: 9065.92326019,
+    cashPnl: 516.0145173668805,
+    percentPnl: 6.035321930190521,
+    totalBought: 29724.338558,
+    realizedPnl: 1,
+    percentRealizedPnl: 6.035321930190521,
+    curPrice: 0.305,
+    redeemable: false,
+    mergeable: false,
+    title: "US strikes Iran by March 31, 2026?",
+    slug: "us-strikes-iran-by-march-31-2026-393",
+    icon: "https://polymarket-upload.s3.us-east-2.amazonaws.com/us-strikes-iran-by-october-3-2sVnIHq3sjqF.jpg",
+    eventId: "114242",
+    eventSlug: "us-strikes-iran-by",
+    outcome: "Yes",
+    outcomeIndex: 0,
+    oppositeOutcome: "No",
+    oppositeAsset: "102493900551645701521693125055452122755587721284263456800351297341161706805154",
+    endDate: "2026-06-30",
+    negativeRisk: false
+  },
+
+];
+
+describe("Polymarket User Data Transformer", () => {
+    
+    const userData: any[] = processUserData(mockUserResponse);
+    const accountData: any = processUserAccountData(mockUserResponse);
+
+    it("Should correctly process user data", () => {
+
+        expect(userData[0].title,
+            "Title should be correctly identified"
+        ).toBe(mockUserResponse[0].title);
+
+        expect(userData[0].size,
+            "Size should be correctly identified"
+        ).toBe(mockUserResponse[0].size);
+
+        expect(userData[0].currentValue,
+            "curentValue should be correctly identified"
+        ).toBe(mockUserResponse[0].currentValue);
+
+        expect(userData[0].slug,
+            "slug should be correctly identified"
+        ).toBe(mockUserResponse[0].slug);
+    });
+    
+    it("Should correctly process account data", () => {
+        expect(accountData.realizedPnl,
+            "Realized PnL should sum across all positions"
+        ).toBe(4);
+        expect(accountData.currentValue,
+            "Total Value should sum across all positions"
+        ).toBe(mockUserResponse[0].currentValue + mockUserResponse[1].currentValue);
+    });
+});

--- a/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/index.ts
+++ b/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/index.ts
@@ -10,6 +10,7 @@ import {
     predictionEventViewHandler,
     portfolioAnalysisHandler,
  } from './actions/polymarket.ts';
+ import { predictionUserPositionsHandler } from './actions/User/index.ts';
 
 /**
  *  Prediction Markets Menu Options.
@@ -58,6 +59,12 @@ const polymarketMenuOptions = (state: TerminalUserStateConfig): MenuOption[] => 
         command: "search [symbol]",
         description: "Fetch available event and market tags useful for filtering.",
         action: polymarketMarketsTagsSearchHandler,
+    },
+    {
+        name: "user positions",
+        command: "user [address]",
+        description: "Fetch user positions for the given address.",
+        action: predictionUserPositionsHandler,
     },
     {
         name: "load",

--- a/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/model/Polymarket.ts
+++ b/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/model/Polymarket.ts
@@ -119,3 +119,15 @@ export async function fetchTopMarketData(limit: number = 10) {
     await pause(1000);
     return response.data;
 }
+
+export async function fetchUserPositions(address: string) {
+    const response = await axios.get(
+        `https://data-api.polymarket.com/positions/`,
+        {
+            params: {
+                user: address,
+            },
+        }
+    );
+    return response.data;
+}

--- a/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/model/Polymarket.ts
+++ b/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/model/Polymarket.ts
@@ -129,5 +129,6 @@ export async function fetchUserPositions(address: string) {
             },
         }
     );
+    await pause(1000);
     return response.data;
 }

--- a/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/model/index.ts
+++ b/open_eth_terminal/PredictionMarketMenu/PolymarketMenu/model/index.ts
@@ -4,6 +4,7 @@ import {
     fetchTopMarketData,
     fetchMarketDataBySlug,
     fetchEventDataBySlug,
+    fetchUserPositions,
 } from "./Polymarket.ts";
 
 const PolymarketData = {
@@ -24,6 +25,9 @@ const PolymarketData = {
     market: {
         getBySlug: fetchMarketDataBySlug,
     },
+    user: {
+        getPositions: fetchUserPositions,
+    }
 }
 
 const PredictionMarketsData = {


### PR DESCRIPTION
# Description

Adds tracking of user positions in the polymarket menu.

# Steps

Navigate to the polymarket menu and run:

```user 0x1abe1368601330a310162064e04d3c2628cb6497```

You should see the data below including a table of user's current positions, as well as account data where it shows their current amount, and total P&L across all trades.

# Screenshot
<img width="1796" height="662" alt="Screenshot from 2026-01-08 14-04-24" src="https://github.com/user-attachments/assets/ec820f38-0b19-421c-828a-9deafd345cfe" />
