### PR TITLE
Fix first character disappearing on MacOS

### DIFF
--- a/open_eth_terminal/utils/program_loader.ts
+++ b/open_eth_terminal/utils/program_loader.ts
@@ -2,7 +2,6 @@ import chalk from "chalk";
 import terminalKit from "terminal-kit";
 const { terminal } = terminalKit;
 import { Command } from "commander";
-import { input as inquirer } from '@inquirer/prompts';
 import {
     CommandState, CommandResultType, Menu, MenuOption,
     TerminalUserStateConfig, LogLevel
@@ -90,8 +89,12 @@ export const registerTerminalApplication = (menu: Menu) => {
                 console.log(chalk.yellow(`Executing script command: ${input}`));
                 isScriptExecution = true;
             } else {
-                const answer = await inquirer({
-                    message: menu.name + " >",
+                terminal(menu.name + " > ");
+                const answer = await new Promise<string>((resolve) => {
+                    terminal.inputField((error, input) => {
+                        terminal('\n');
+                        resolve(input || '');
+                    });
                 });
                 input = answer?.trim();
             }


### PR DESCRIPTION
## Summary
- Replace `@inquirer/prompts` with terminal-kit's native `inputField()` for user input
- Ensures consistent terminal handling since both table rendering and input now use the same library
- Fixes readline conflict that caused first keystroke to be swallowed on MacOS

## Test plan
- [x] Test on MacOS - first character no longer disappears when entering commands
- [x] Verify Windows/Linux behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)