### PR TITLE
Fix crash when entering 'back' at main menu

### DIFF
--- a/open_eth_terminal/utils/menu_globals.ts
+++ b/open_eth_terminal/utils/menu_globals.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import { ActionOptions, CommandResultType, TerminalUserStateConfig, EnvironmentType, MenuOption } from "../types.ts";
 
 const menu_back: MenuOption = {
@@ -7,6 +8,19 @@ const menu_back: MenuOption = {
     action: (st: TerminalUserStateConfig) => async (ops?: ActionOptions) => {
         return {
             result: { type: CommandResultType.Back },
+            state: st,
+        };
+    },
+};
+
+const menu_back_top: MenuOption = {
+    name: "back",
+    command: "back",
+    description: "Go back to the previous menu",
+    action: (st: TerminalUserStateConfig) => async (ops?: ActionOptions) => {
+        console.log(chalk.yellow("You are already at the main menu."));
+        return {
+            result: { type: CommandResultType.Success },
             state: st,
         };
     },
@@ -60,7 +74,7 @@ export const menuGlobals = (st: TerminalUserStateConfig): MenuOption[] => {
  */
 export const menuGlobalsTop = (st: TerminalUserStateConfig): MenuOption[] => {
     if (st.environment === EnvironmentType.Development) {
-        return [menu_top, menu_showconfig];
+        return [menu_top, menu_back_top, menu_showconfig];
     }
-    return [menu_top, menu_back];
+    return [menu_top, menu_back_top];
 }


### PR DESCRIPTION
## Summary
- Fixes crash when typing "back" at the main menu in Windows (Tabby Terminal)
- Added `menu_back_top` variant that shows friendly message instead of crashing
- Users now see "You are already at the main menu." in yellow text

## Test plan
- [x] Run app and type "back" at main menu - should show friendly message
- [x] Navigate to submenu, type "back" - should return to main menu normally
- [x] Verify app doesn't crash in either scenario

Fixes #58

🤖 Generated with [Claude Code](https://claude.ai/code)