### PR TITLE
feat(bonds): add bond yield charting via Yahoo Finance

### DIFF
--- a/cli/BondsMenu/actions/yields.ts
+++ b/cli/BondsMenu/actions/yields.ts
@@ -1,0 +1,84 @@
+import chalk from "chalk";
+import { YahooFinanceBonds } from "../services/YahooFinanceBondsService.ts";
+import { ChartRenderer } from "../../StocksMenu/services/ChartRenderer.ts";
+import { BOND_TICKER_MAP, type YieldPoint } from "../types.ts";
+import { DataSourceType, TerminalUserStateConfigContext } from "../../types.ts";
+import { CommandResultType } from "../../types.ts";
+import { Effect } from "effect";
+
+/**
+ * Parse a bond code like "US10" into its Yahoo ticker and label.
+ * Returns null if the code is unknown.
+ */
+const parseBondCode = (code: string): { ticker: string; label: string } | null => {
+  const upper = code.toUpperCase();
+  const entry = BOND_TICKER_MAP[upper];
+  if (entry) return entry;
+
+  // Try matching partial: e.g. "10" -> "US10"
+  const match = Object.entries(BOND_TICKER_MAP).find(([key]) =>
+    key.endsWith(upper) || key.replace("US", "").endsWith(upper)
+  );
+  if (match) return match[1];
+
+  return null;
+};
+
+export const yieldsHandler = (bondCode: string, range?: string) =>
+  Effect.gen(function* () {
+    const st = yield* TerminalUserStateConfigContext;
+
+    if (!bondCode) {
+      console.log(chalk.red("No bond code provided. Usage: yields <code> [range]"));
+      console.log(chalk.dim("Available codes: US2, US5, US10, US30"));
+      console.log(chalk.dim("Optional range: 1mo, 3mo, 6mo, 1y (default), 2y, 5y, 10y, max"));
+      return { result: { type: CommandResultType.Error }, state: st };
+    }
+
+    const parsed = parseBondCode(bondCode);
+    if (!parsed) {
+      console.log(chalk.red(`Unknown bond code: ${bondCode}`));
+      console.log(chalk.dim("Available codes: US2, US5, US10, US30"));
+      return { result: { type: CommandResultType.Error }, state: st };
+    }
+
+    const symbolObj = {
+      name: parsed.label,
+      id: parsed.ticker,
+      _type: DataSourceType.YahooFinance,
+    };
+
+    const yf = yield* YahooFinanceBonds;
+    const rangeStr = range || "1y";
+
+    yield* Effect.logInfo(`Fetching ${parsed.label} bond yields (range=${rangeStr})`);
+
+    const points: readonly YieldPoint[] = yield* yf.getYields(symbolObj, rangeStr);
+
+    if (points.length === 0) {
+      console.log(chalk.red("No yield data returned"));
+      return { result: { type: CommandResultType.Error }, state: st };
+    }
+
+    // Show latest yield
+    const latest = points[points.length - 1];
+    const first = points[0];
+    const change = latest.close - first.close;
+    const direction = change >= 0 ? chalk.green("▲") : chalk.red("▼");
+    const changeColor = change >= 0 ? chalk.green : chalk.red;
+
+    console.log(chalk.bold(`\n${parsed.label} Bond Yield`));
+    console.log(`Latest: ${chalk.bold.white(`${latest.close.toFixed(3)}%`)}  ${direction} ${changeColor(`${change.toFixed(3)}%`)}`);
+    console.log(`Range:  ${first.date} → ${latest.date}  ·  ${points.length} data points\n`);
+
+    // Render chart
+    const chart = yield* ChartRenderer;
+    yield* chart.render(
+      [...points] as unknown as Record<string, unknown>[],
+      "date",
+      "close",
+      `${parsed.label} Yield (${rangeStr})`,
+    );
+
+    return { result: { type: CommandResultType.Success }, state: st };
+  });

--- a/cli/BondsMenu/index.ts
+++ b/cli/BondsMenu/index.ts
@@ -1,0 +1,27 @@
+import { registerTerminalApplication } from "../utils/program_loader.ts";
+import { Menu, MenuOption, TerminalUserStateConfig, TerminalUserStateConfigContext, CommandResultType } from "cli/types.ts";
+import { menuGlobals } from "../utils/menu_globals.ts";
+import { yieldsHandler } from "./actions/yields.ts";
+import { Effect } from "effect";
+import { BondsServiceLive } from "./services/index.ts";
+
+const bondsMenuOptions = (state: TerminalUserStateConfig): MenuOption[] => [
+  {
+    name: "yields",
+    command: "yields <code> [range]",
+    description: "Fetch bond yield chart. Codes: US2, US5, US10, US30. Range: 1mo-10y (default 1y)",
+    action: (bondCode: string, range?: string) =>
+      yieldsHandler(bondCode, range).pipe(Effect.provide(BondsServiceLive)),
+  },
+  ...menuGlobals(state),
+];
+
+const bondsMenu: Menu = {
+  name: "Bonds Menu",
+  description: "Bonds Menu",
+  messagePrompt: "Select an option:",
+  options: bondsMenuOptions,
+};
+
+export const bondsTerminal = registerTerminalApplication(bondsMenu);
+export default bondsTerminal;

--- a/cli/BondsMenu/services/YahooFinanceBondsService.ts
+++ b/cli/BondsMenu/services/YahooFinanceBondsService.ts
@@ -1,0 +1,165 @@
+import { Effect, Context, Layer, Schema } from "effect";
+import { ConfigError, HTTPError, ProgramError } from "cli/errors/index.ts";
+import { BondSymbolType, YieldPoint } from "../types.ts";
+
+// ── Yahoo Finance API constants ──
+
+const YAHOO_BASE = "https://query2.finance.yahoo.com";
+const YAHOO_FC = "https://fc.yahoo.com";
+
+// ── Raw response schemas ──
+
+const ChartMetaRaw = Schema.Struct({
+  currency: Schema.optional(Schema.String),
+  symbol: Schema.String,
+  regularMarketPrice: Schema.optional(Schema.Number),
+  chartPreviousClose: Schema.optional(Schema.Number),
+  validRanges: Schema.Array(Schema.String),
+});
+
+const ChartResultRaw = Schema.Struct({
+  meta: ChartMetaRaw,
+  timestamp: Schema.optional(Schema.Array(Schema.Number)),
+  indicators: Schema.Struct({
+    quote: Schema.Array(
+      Schema.Struct({
+        close: Schema.optional(Schema.Array(Schema.NullishOr(Schema.Number))),
+      }),
+    ),
+  }),
+});
+
+const ChartResponseRaw = Schema.Struct({
+  chart: Schema.Struct({
+    result: Schema.Array(ChartResultRaw),
+    error: Schema.NullishOr(
+      Schema.Struct({
+        code: Schema.String,
+        description: Schema.String,
+      }),
+    ),
+  }),
+});
+
+// ── Decode helpers ──
+
+const decodeChartResponse = (raw: unknown) =>
+  Schema.decodeUnknown(ChartResponseRaw)(raw).pipe(
+    Effect.catchTag("ParseError", (e) =>
+      Effect.logDebug(`Yahoo Finance chart response shape changed: ${e.message}`).pipe(
+        Effect.andThen(
+          Effect.fail(
+            new HTTPError({ message: `Invalid Yahoo Finance chart response: ${e.message}` }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+// ── Cookie-aware fetch helper ──
+// Reuses the same pattern from YahooFinanceOptionsService.
+
+let _cookieHeader: string | null = null;
+
+const UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+const yahooFetch = (url: string): Effect.Effect<Response, HTTPError> =>
+  Effect.tryPromise({
+    try: () =>
+      fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          ...(_cookieHeader ? { Cookie: _cookieHeader } : {}),
+        },
+        redirect: "manual",
+      }),
+    catch: () => new HTTPError({ message: `Failed to fetch: ${url}` }),
+  });
+
+const saveCookies = (response: Response) => {
+  const setCookie = response.headers.get("set-cookie");
+  if (setCookie) {
+    const match = setCookie.match(/A3=[^;]+/);
+    if (match) {
+      _cookieHeader = match[0];
+    }
+  }
+};
+
+const getCrumb = Effect.gen(function* () {
+  const fcResp = yield* yahooFetch(YAHOO_FC);
+  saveCookies(fcResp);
+
+  if (!_cookieHeader) {
+    return yield* new HTTPError({ message: "Failed to get Yahoo Finance cookie" });
+  }
+
+  const crumbResp = yield* yahooFetch(`${YAHOO_BASE}/v1/test/getcrumb`);
+  const crumb = yield* Effect.tryPromise({
+    try: () => crumbResp.text(),
+    catch: () => new HTTPError({ message: "Failed to read Yahoo crumb response" }),
+  });
+
+  if (crumb.includes("<html>") || crumb.includes("Too Many Requests") || crumb === "") {
+    return yield* new HTTPError({ message: "Yahoo Finance rate limited or unavailable" });
+  }
+
+  return crumb;
+});
+
+// ── Service port ──
+
+export interface YahooFinanceBondsPort {
+  readonly getYields: (
+    symbol: BondSymbolType,
+    range?: string,
+  ) => Effect.Effect<readonly YieldPoint[], ProgramError>;
+}
+
+export class YahooFinanceBonds extends Context.Tag("hyperfin.bonds.services.YahooFinance")<
+  YahooFinanceBonds,
+  YahooFinanceBondsPort
+>() {}
+
+// ── Live implementation ──
+
+export const YahooFinanceBondsLive = Layer.effect(
+  YahooFinanceBonds,
+  Effect.succeed({
+    getYields: (symbol: BondSymbolType, range = "1y") =>
+      Effect.gen(function* () {
+        const crumb = yield* getCrumb;
+        const url =
+          `${YAHOO_BASE}/v8/finance/chart/${symbol.id}?range=${range}&interval=1d&includePrePost=false&crumb=${crumb}`;
+        const resp = yield* yahooFetch(url);
+        const text = yield* Effect.tryPromise({
+          try: () => resp.json(),
+          catch: () => new HTTPError({ message: "Failed to parse Yahoo chart response" }),
+        });
+        const validated = yield* decodeChartResponse(text);
+
+        const result = validated.chart.result[0];
+        if (!result) {
+          return yield* new HTTPError({ message: "No chart data returned from Yahoo Finance" });
+        }
+
+        const timestamps = result.timestamp ?? [];
+        const closes = result.indicators.quote[0]?.close ?? [];
+
+        const points: YieldPoint[] = [];
+        for (let i = 0; i < timestamps.length; i++) {
+          const close = closes[i];
+          if (close != null && !isNaN(close)) {
+            points.push({
+              timestamp: timestamps[i],
+              date: new Date(timestamps[i] * 1000).toISOString().slice(0, 10),
+              close,
+            });
+          }
+        }
+
+        return points;
+      }),
+  } satisfies YahooFinanceBondsPort),
+);

--- a/cli/BondsMenu/services/index.ts
+++ b/cli/BondsMenu/services/index.ts
@@ -1,0 +1,8 @@
+import { Layer } from "effect";
+import { YahooFinanceBondsLive } from "./YahooFinanceBondsService.ts";
+import { ChartRendererLive } from "../../StocksMenu/services/ChartRenderer.ts";
+
+export const BondsServiceLive = Layer.mergeAll(
+  YahooFinanceBondsLive,
+  ChartRendererLive,
+);

--- a/cli/BondsMenu/types.ts
+++ b/cli/BondsMenu/types.ts
@@ -1,0 +1,43 @@
+import { DataSourceType } from "../types.ts";
+import { Schema } from "effect";
+
+export const BondsDataSourceTypeSchema = Schema.Literal(
+  DataSourceType.YahooFinance,
+);
+
+export type BondsDataSourceType = typeof BondsDataSourceTypeSchema.Type;
+
+export interface BondSymbolType {
+  name: string;
+  id: string;
+  _type: DataSourceType;
+}
+
+/**
+ * Mapping from user-facing bond codes (e.g. "US2", "US10") to
+ * Yahoo Finance ticker symbols.
+ *
+ * Uses CBOE Interest Rate indexes available on Yahoo Finance:
+ *   ^IRX = 13-Week Treasury Bill (closest short-term proxy)
+ *   ^FVX = 5-Year Treasury Note
+ *   ^TNX = 10-Year Treasury Note
+ *   ^TYX = 30-Year Treasury Bond
+ *
+ * Note: Yahoo Finance does not have a dedicated 2-year or 20-year
+ * CBOE yield index. ^IRX (13-week T-bill) is used as the closest
+ * short-term proxy for US2. US20 is omitted until a suitable data
+ * source is available.
+ */
+export const BOND_TICKER_MAP: Record<string, { ticker: string; label: string }> = {
+  US2:  { ticker: "^IRX",  label: "US 2-Year (13W proxy)" },
+  US5:  { ticker: "^FVX",  label: "US 5-Year" },
+  US10: { ticker: "^TNX",  label: "US 10-Year" },
+  US30: { ticker: "^TYX",  label: "US 30-Year" },
+};
+
+/** A single yield data point from the chart API. */
+export interface YieldPoint {
+  timestamp: number;
+  date: string;
+  close: number;
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -4,6 +4,7 @@ import cryptoTerminal from "./CryptoMenu/index.ts";
 import predictionMarketsTerminal from "./PredictionMarketMenu/index.ts";
 import stocksTerminal from "./StocksMenu/index.ts";
 import optionsTerminal from "./OptionsMenu/index.ts";
+import bondsTerminal from "./BondsMenu/index.ts";
 import { menuGlobalsTop } from "./utils/menu_globals.ts";
 import newsTerminal from "./NewsMenu/index.ts";
 import { executeScript } from "./utils/scripts.ts";
@@ -50,6 +51,19 @@ const menuOptions = (state: TerminalUserStateConfig): MenuOption[] => ([
         action: () => Effect.gen(function*() {
             const st = yield* TerminalUserStateConfigContext;
             const newState = yield* Effect.promise(async () => optionsTerminal(st));
+            return {
+                result: { type: CommandResultType.Success },
+                state: newState,
+            };
+        })
+    },
+    {
+        name: "bonds",
+        command: "bonds",
+        description: "Fetch bond yields from Yahoo Finance",
+        action: () => Effect.gen(function*() {
+            const st = yield* TerminalUserStateConfigContext;
+            const newState = yield* Effect.promise(async () => bondsTerminal(st));
             return {
                 result: { type: CommandResultType.Success },
                 state: newState,


### PR DESCRIPTION
## Summary

Adds a new **BondsMenu** to the CLI with a `yields` command that fetches historical bond yield data from Yahoo Finance and renders it as an Observable Plot line chart.

## Supported Bond Codes

| Code | Yahoo Ticker | Description |
|------|-------------|-------------|
| `US2` | `^IRX` | 13-Week T-Bill (short-term proxy) |
| `US5` | `^FVX` | 5-Year Treasury Note |
| `US10` | `^TNX` | 10-Year Treasury Note |
| `US30` | `^TYX` | 30-Year Treasury Bond |

## Usage

```
Main Menu > bonds
Bonds Menu > yields US10
Bonds Menu > yields US10 5y
Bonds Menu > yields US5 1mo
```

Optional range: `1mo`, `3mo`, `6mo`, `1y` (default), `2y`, `5y`, `10y`, `max`

## Architecture

Follows the existing StocksMenu/OptionsMenu patterns:
- **YahooFinanceBondsService** — cookie+crumb auth, fetches `/v8/finance/chart/{ticker}`
- **ChartRenderer** — Observable Plot SVG output opened in browser
- **Effect.ts** service layer with proper dependency injection

## Notes

- Yahoo Finance does not have a dedicated CBOE yield index for the 2-year or 20-year. `^IRX` (13-week T-bill) is used as the closest short-term proxy. The 20-year is omitted until a suitable data source is available (e.g. FRED API `DGS20`).